### PR TITLE
Customize oai provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,34 +64,10 @@ include BlacklightOaiProvider::Controller
 
 While the plugin provides some sensible (albeit generic) defaults out of the box, you probably will want to customize the OAI provider configuration.
 
+### Configuring the OAI PMH service
+You can provide OAI-PMH provider parameters by placing the following in your blacklight configuration, See [Configuring the OAI PMH service](https://github.com/CottageLabs/projectblacklight_blacklight_oai_provider/wiki/Configuring-the-OAI-PMH-service)
+
 ### Blacklight configuration
-You can provide OAI-PMH provider parameters by placing the following in your blacklight configuration (most likely in `app/controllers/catalog_controller.rb`)
-
-```ruby
-configure_blacklight do |config|
-
-  # ...
-
-  config.oai = {
-    provider: {
-      repository_name: 'Test',
-      repository_url: 'http://localhost/catalog/oai',
-      record_prefix: 'oai:test',
-      admin_email: 'root@localhost',
-      sample_id: '109660'
-    },
-    document: {
-      limit: 25,            # number of records returned with each request, default: 15
-      set_fields: [        # ability to define ListSets, optional, default: nil
-        { label: 'language', solr_field: 'language_facet' }
-      ]
-    }
-  }
-
-  # ...
-end
-```
-
 The "provider" configuration is documented as part of the ruby-oai gem at https://github.com/code4lib/ruby-oai and can be lambdas for dynamic configuration (e.g. `repository_name: ->(controller) { controller.send(:repository_name) }`).
 
 A basic set model is included that maps Solr fields to OAI sets. Provide `set_fields` with an array of hashes defining the solr_field, and optionally a label and description. The configuration above will cause the `ListSets` verb to query Solr for unique values of the `language_facet` field and present each value as a set using a spec format of `language:value`. When the `set` parameter is supplied to the `ListRecords` verb, it will append a filter to the Solr query of the form `fq=language_facet:value`. If no label is provided, the set will use the `solr_field` name. To customize the ListSet implementation, see [customizing listsets](#customizing-listsets).

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A properly configured documentHandler in the blacklight/solr configuration.
 Add
 
 ```ruby
-    gem 'blacklight_oai_provider'
+    gem 'blacklight_oai_provider', git: 'https://github.com/CottageLabs/projectblacklight_blacklight_oai_provider.git', branch: 'main'
 ```
 
 to your Gemfile and run `bundle install`.

--- a/app/assets/stylesheets/blacklight_oai_provider/oai2.xsl
+++ b/app/assets/stylesheets/blacklight_oai_provider/oai2.xsl
@@ -152,6 +152,7 @@ p.intro {
 
 <xsl:variable name="identifier" select="/oai:OAI-PMH/oai:request/@identifier" />
 <xsl:variable name="verb" select="/oai:OAI-PMH/oai:request/@verb" />
+<xsl:variable name="metadataPrefix" select="/oai:OAI-PMH/oai:request/@metadataPrefix" />
 
 <xsl:template match="/">
 <html>
@@ -492,6 +493,8 @@ p.intro {
     <td class="value">
       <xsl:value-of select="oai:identifier"/>
       <xsl:text> </xsl:text><a class="link" href="?verb=GetRecord&amp;metadataPrefix=oai_dc&amp;identifier={oai:identifier}">oai_dc</a>
+      <xsl:text> </xsl:text><a class="link" href="?verb=GetRecord&amp;metadataPrefix=mods&amp;identifier={oai:identifier}">MODs</a>
+      <xsl:text> </xsl:text><a class="link" href="?verb=GetRecord&amp;metadataPrefix=uketd_dc&amp;identifier={oai:identifier}">uketd_dc</a>
       <xsl:text> </xsl:text><a class="link" href="?verb=ListMetadataFormats&amp;identifier={oai:identifier}">formats</a>
     </td></tr>
     <tr><td class="key">Datestamp</td>
@@ -552,7 +555,7 @@ p.intro {
 <!-- unknown metadata format -->
 
 <xsl:template match="oai:metadata/*" priority='-100'>
-  <h3>Unknown Metadata Format</h3>
+  <h3>Metadata Format: <xsl:value-of select="$metadataPrefix" /></h3>
   <div class="xmlSource">
     <xsl:apply-templates select="." mode='xmlMarkup' />
   </div>

--- a/lib/blacklight_oai_provider/set.rb
+++ b/lib/blacklight_oai_provider/set.rb
@@ -8,6 +8,9 @@ module BlacklightOaiProvider
       # Fields must be indexed
       attr_accessor :fields
 
+      # The solr filter queries to exclude certain set values (optional)
+      attr_accessor :filters
+
       # Return an array of all SetSpecs, or nil if sets are not supported.
       # Objects returned must be of a class that inherits from
       # BlacklightOaiProvider::SetSpecs.

--- a/lib/blacklight_oai_provider/solr_document_provider.rb
+++ b/lib/blacklight_oai_provider/solr_document_provider.rb
@@ -27,6 +27,22 @@ module BlacklightOaiProvider
         v = v.call(controller) if v.is_a?(Proc)
         send :"#{k}=", v
       end
+
+      @supported_formats = options.dig(:document, :supported_formats)
+      @supported_formats = ['oai_dc'] if @supported_formats.blank?
+    end
+
+    def process_request(params = {})
+      begin
+        validate_metadata_format(params[:verb], params[:metadataPrefix]) if params[:resumptionToken].blank?
+        validate_granularity(params[:from], params[:until]) if params[:from] && params[:until]
+        params[:from] = parse_date(params[:from]) if params[:from]
+        params[:until] = parse_date(params[:until]) if params[:until]
+      rescue => err
+        return OAI::Provider::Response::Error.new(self.class, err).to_xml
+      end
+
+      super params
     end
 
     def list_sets(options = {})
@@ -38,6 +54,18 @@ module BlacklightOaiProvider
       PROVIDER_INSTANCE_ATTRS.each { |inst_att, class_att| instance_options[inst_att] ||= instance_options.delete(class_att) }
       instance_options.delete_if { |k, _v| PROVIDER_INSTANCE_ATTRS[k].nil? }
       instance_options
+    end
+
+    def validate_granularity(from, to)
+      raise(OAI::ArgumentException.new, "Date granularities do not match! #{from} - #{to}") unless from.length == to.length
+    end
+
+    def validate_metadata_format(verb, metadata_prefix)
+      if ['ListIdentifiers', 'ListRecords', 'GetRecord'].include? verb
+        raise(OAI::ArgumentException.new, "metadataPrefix not provided") if metadata_prefix.blank?
+        return metadata_prefix if @supported_formats.include? metadata_prefix
+        raise(OAI::FormatException.new, "metadataPrefix not supported")
+      end
     end
   end
 end

--- a/lib/blacklight_oai_provider/solr_document_wrapper.rb
+++ b/lib/blacklight_oai_provider/solr_document_wrapper.rb
@@ -11,6 +11,11 @@ module BlacklightOaiProvider
       @set             = options[:set_model] || BlacklightOaiProvider::SolrSet
       @granularity = options[:granularity] || OAI::Const::Granularity::HIGH
 
+      if @set.respond_to?(:filters=)
+        @set.filters = Array.wrap(options[:set_filters])
+        @set.filters.concat(Array.wrap(options[:record_filters]))
+      end
+
       @set.controller = @controller
       @set.fields = options[:set_fields]
     end
@@ -81,6 +86,12 @@ module BlacklightOaiProvider
       end
 
       query.append_filter_query(@set.from_spec(constraints[:set])) if constraints[:set].present?
+
+      # Filter documents
+      Array(@options[:record_filters]).each do |f|
+        query.append_filter_query(f)
+      end
+
       query
     end
 

--- a/lib/blacklight_oai_provider/solr_document_wrapper.rb
+++ b/lib/blacklight_oai_provider/solr_document_wrapper.rb
@@ -54,6 +54,17 @@ module BlacklightOaiProvider
       else
         # search_service.fetch(selector).first.documents.first
         query = search_service.search_builder.where(id: selector).query
+
+        # Filter documents
+        Array(@options[:record_filters]).each do |f|
+          query.append_filter_query(f)
+        end
+
+        # Add format filters
+        Array(@options[:format_filters]).each do |f|
+          query.append_filter_query(f)
+        end
+
         search_service.repository.search(query).documents.first
       end
     end
@@ -90,6 +101,11 @@ module BlacklightOaiProvider
 
       # Filter documents
       Array(@options[:record_filters]).each do |f|
+        query.append_filter_query(f)
+      end
+
+      # Add format filters
+      Array(@options[:format_filters]).each do |f|
         query.append_filter_query(f)
       end
 

--- a/lib/blacklight_oai_provider/solr_document_wrapper.rb
+++ b/lib/blacklight_oai_provider/solr_document_wrapper.rb
@@ -3,21 +3,22 @@ module BlacklightOaiProvider
     attr_reader :document_model, :timestamp_field, :solr_timestamp, :limit, :granularity
 
     def initialize(controller, options = {})
+      @options = options
       @controller      = controller
       @document_model  = @controller.blacklight_config.document_model
       @solr_timestamp  = document_model.timestamp_key
       @timestamp_field = 'timestamp' # method name used by ruby-oai
-      @limit           = options[:limit] || 15
-      @set             = options[:set_model] || BlacklightOaiProvider::SolrSet
-      @granularity = options[:granularity] || OAI::Const::Granularity::HIGH
+      @limit           = @options[:limit] || 15
+      @set             = @options[:set_model] || BlacklightOaiProvider::SolrSet
+      @granularity = @options[:granularity] || OAI::Const::Granularity::HIGH
 
       if @set.respond_to?(:filters=)
-        @set.filters = Array.wrap(options[:set_filters])
-        @set.filters.concat(Array.wrap(options[:record_filters]))
+        @set.filters = Array.wrap(@options[:set_filters])
+        @set.filters.concat(Array.wrap(@options[:record_filters]))
       end
 
       @set.controller = @controller
-      @set.fields = options[:set_fields]
+      @set.fields = @options[:set_fields]
     end
 
     def sets


### PR DESCRIPTION
We have introduced set filers, record filters, and format filters, which can be added to the OAI configuration, as documented in https://github.com/CottageLabs/projectblacklight_blacklight_oai_provider/wiki/Configuring-the-OAI-PMH-service