### PR TITLE
Add parse_date method to SolrDocumentProvider

### DIFF
--- a/lib/blacklight_oai_provider/solr_document_provider.rb
+++ b/lib/blacklight_oai_provider/solr_document_provider.rb
@@ -67,5 +67,17 @@ module BlacklightOaiProvider
         raise(OAI::FormatException.new, "metadataPrefix not supported")
       end
     end
+
+    def parse_date(value)
+      return value if value.respond_to?(:strftime)
+
+      if value[-1] == "Z"
+        Time.strptime(value, "%Y-%m-%dT%H:%M:%S%Z").utc
+      else
+        Date.strptime(value, "%Y-%m-%d")
+      end
+    rescue ArgumentError => err
+      raise(OAI::ArgumentException.new, "unparsable date: '#{value}'")
+    end
   end
 end


### PR DESCRIPTION
The SolrDocumentProvider class lacks a parse_date method. Because of this, the 'process_request' method fails if a date is passed to it.

This PR adds the parse_date method from OAI::Provider::Request::Base using SolrDocumentProvider's error handling code